### PR TITLE
Crystal dissolution stability

### DIFF
--- a/contracts/crystal-nexus.clar
+++ b/contracts/crystal-nexus.clar
@@ -98,3 +98,61 @@
     )
   )
 )
+
+
+;; Originator requests crystal dissolution
+(define-public (dissolve-crystal (crystal-id uint))
+  (begin
+    (asserts! (valid-crystal-id? crystal-id) ERR_INVALID_IDENTIFIER)
+    (let
+      (
+        (crystal-data (unwrap! (map-get? CrystalLattice { crystal-id: crystal-id }) ERR_NO_CRYSTAL))
+        (originator (get originator crystal-data))
+        (energy (get energy crystal-data))
+      )
+      (asserts! (is-eq tx-sender originator) ERR_PERMISSION_DENIED)
+      (asserts! (is-eq (get lattice-state crystal-data) "stabilizing") ERR_ALREADY_PROCESSED)
+      (asserts! (<= block-height (get decay-block crystal-data)) ERR_CRYSTAL_DECAYED)
+      (match (as-contract (stx-transfer? energy tx-sender originator))
+        success
+          (begin
+            (map-set CrystalLattice
+              { crystal-id: crystal-id }
+              (merge crystal-data { lattice-state: "dissolved" })
+            )
+            (print {action: "crystal_dissolved", crystal-id: crystal-id, originator: originator, energy: energy})
+            (ok true)
+          )
+        error ERR_TRANSMISSION_FAILED
+      )
+    )
+  )
+)
+
+;; Extend crystal stability period
+(define-public (extend-crystal-stability (crystal-id uint) (additional-blocks uint))
+  (begin
+    (asserts! (valid-crystal-id? crystal-id) ERR_INVALID_IDENTIFIER)
+    (asserts! (> additional-blocks u0) ERR_INVALID_QUANTITY)
+    (asserts! (<= additional-blocks u1440) ERR_INVALID_QUANTITY) ;; Max ~10 days extension
+    (let
+      (
+        (crystal-data (unwrap! (map-get? CrystalLattice { crystal-id: crystal-id }) ERR_NO_CRYSTAL))
+        (originator (get originator crystal-data)) 
+        (beneficiary (get beneficiary crystal-data))
+        (current-decay (get decay-block crystal-data))
+        (updated-decay (+ current-decay additional-blocks))
+      )
+      (asserts! (or (is-eq tx-sender originator) (is-eq tx-sender beneficiary) (is-eq tx-sender PROTOCOL_SUPERVISOR)) ERR_PERMISSION_DENIED)
+      (asserts! (or (is-eq (get lattice-state crystal-data) "stabilizing") (is-eq (get lattice-state crystal-data) "acknowledged")) ERR_ALREADY_PROCESSED)
+      (map-set CrystalLattice
+        { crystal-id: crystal-id }
+        (merge crystal-data { decay-block: updated-decay })
+      )
+      (print {action: "stability_extended", crystal-id: crystal-id, requester: tx-sender, new-decay-block: updated-decay})
+      (ok true)
+    )
+  )
+)
+
+

--- a/contracts/crystal-nexus.clar
+++ b/contracts/crystal-nexus.clar
@@ -26,3 +26,75 @@
     decay-block: uint
   }
 )
+
+
+;; Tracking the highest crystal identifier
+(define-data-var latest-crystal-id uint u0)
+
+;; Utility functions for system integrity
+(define-private (valid-beneficiary? (beneficiary principal))
+  (and 
+    (not (is-eq beneficiary tx-sender))
+    (not (is-eq beneficiary (as-contract tx-sender)))
+  )
+)
+
+(define-private (valid-crystal-id? (crystal-id uint))
+  (<= crystal-id (var-get latest-crystal-id))
+)
+
+;; Protocol interaction functions
+
+;; Complete transmission of crystal energy to beneficiary
+(define-public (finalize-energy-transmission (crystal-id uint))
+  (begin
+    (asserts! (valid-crystal-id? crystal-id) ERR_INVALID_IDENTIFIER)
+    (let
+      (
+        (crystal-data (unwrap! (map-get? CrystalLattice { crystal-id: crystal-id }) ERR_NO_CRYSTAL))
+        (beneficiary (get beneficiary crystal-data))
+        (energy (get energy crystal-data))
+        (wavelength (get wavelength crystal-data))
+      )
+      (asserts! (or (is-eq tx-sender PROTOCOL_SUPERVISOR) (is-eq tx-sender (get originator crystal-data))) ERR_PERMISSION_DENIED)
+      (asserts! (is-eq (get lattice-state crystal-data) "stabilizing") ERR_ALREADY_PROCESSED)
+      (asserts! (<= block-height (get decay-block crystal-data)) ERR_CRYSTAL_DECAYED)
+      (match (as-contract (stx-transfer? energy tx-sender beneficiary))
+        success
+          (begin
+            (print {action: "crystal_transmitted", crystal-id: crystal-id, beneficiary: beneficiary, wavelength: wavelength, energy: energy})
+            (ok true)
+          )
+        error ERR_TRANSMISSION_FAILED
+      )
+    )
+  )
+)
+
+;; Redirect crystal energy to originator
+(define-public (revert-crystal-energy (crystal-id uint))
+  (begin
+    (asserts! (valid-crystal-id? crystal-id) ERR_INVALID_IDENTIFIER)
+    (let
+      (
+        (crystal-data (unwrap! (map-get? CrystalLattice { crystal-id: crystal-id }) ERR_NO_CRYSTAL))
+        (originator (get originator crystal-data))
+        (energy (get energy crystal-data))
+      )
+      (asserts! (is-eq tx-sender PROTOCOL_SUPERVISOR) ERR_PERMISSION_DENIED)
+      (asserts! (is-eq (get lattice-state crystal-data) "stabilizing") ERR_ALREADY_PROCESSED)
+      (match (as-contract (stx-transfer? energy tx-sender originator))
+        success
+          (begin
+            (map-set CrystalLattice
+              { crystal-id: crystal-id }
+              (merge crystal-data { lattice-state: "reverted" })
+            )
+            (print {action: "energy_reverted", crystal-id: crystal-id, originator: originator, energy: energy})
+            (ok true)
+          )
+        error ERR_TRANSMISSION_FAILED
+      )
+    )
+  )
+)


### PR DESCRIPTION
## Overview  
This pull request introduces new contract functionalities allowing originators to dissolve crystals and extend their stability period.

## Changes Introduced  
### **New Clarity Contract Functionality**
- **`dissolve-crystal`**  
  - Allows the originator of a crystal to dissolve it, transferring its remaining energy back to them.
  - Ensures permission validation before processing the request.
  - Prevents dissolution if the crystal has already decayed or been processed.

- **`extend-crystal-stability`**  
  - Allows the originator, beneficiary, or protocol supervisor to extend the crystal's stability period by up to ~10 days.
  - Validates input to prevent invalid or excessive extension requests.
  - Updates the `decay-block` value accordingly.

### **Security Enhancements**
- Enforces strict permission checks to prevent unauthorized modifications.
- Validates `crystal-id` and ensures valid transaction states before proceeding.

### **Optimizations & Refactoring**
- Consolidates validation logic to improve code maintainability.
- Enhances state management for crystal dissolution and stability extensions.

## Why This Change?  
- Provides originators with a mechanism to reclaim energy from unused crystals.
- Introduces flexibility in managing crystal decay, preventing premature energy loss.
- Strengthens contract security and reduces potential misuse.

## Testing  
- Additional test cases will be required to verify:
  - Proper dissolution behavior.
  - Correct permission handling for stability extensions.
  - Edge cases for invalid inputs and state transitions.

## Next Steps  
- Expand the test suite to cover new functionalities.
- Consider additional security mechanisms for decay extensions.
